### PR TITLE
ci: add .releaserc.yml for release pipeline

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,12 @@
+---
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/github"
+  - - "@semantic-release/changelog"
+    - changelogFile: CHANGELOG.md
+  - - "@semantic-release/git"
+    - assets:
+        - CHANGELOG.md
+branches:
+  - "main"


### PR DESCRIPTION
Adds missing config file needed to determine the release branch for repo.